### PR TITLE
Try sorting on the reduce side

### DIFF
--- a/src/main/java/com/cloudera/science/quince/CrunchUtils.java
+++ b/src/main/java/com/cloudera/science/quince/CrunchUtils.java
@@ -15,8 +15,13 @@
 
 package com.cloudera.science.quince;
 
+import com.google.common.collect.Lists;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 import org.apache.crunch.DoFn;
 import org.apache.crunch.Emitter;
+import org.apache.crunch.MapFn;
 import org.apache.crunch.PCollection;
 import org.apache.crunch.PTable;
 import org.apache.crunch.Pair;
@@ -26,16 +31,20 @@ import org.apache.crunch.types.avro.Avros;
 import org.ga4gh.models.Call;
 import org.ga4gh.models.FlatVariantCall;
 import org.ga4gh.models.Variant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static com.cloudera.science.quince.FlattenVariantFn.flatten;
 import static org.apache.crunch.types.avro.Avros.*;
 
 public final class CrunchUtils {
 
+  private static final Logger LOG = LoggerFactory.getLogger(CrunchUtils.class);
+
   private CrunchUtils() {
   }
 
-  public static PTable<String, FlatVariantCall> partitionAndSort(
+  public static PTable<String, FlatVariantCall> partitionAndSortUsingShuffle(
       PCollection<Variant> records, long segmentSize, String sampleGroup) {
     // flatten variants
     PCollection<FlatVariantCall> flatRecords = records.parallelDo(
@@ -43,13 +52,32 @@ public final class CrunchUtils {
     // group by partition key (table key), then prepare for sorting by secondary key,
     // which is the sample ID and position (first element in value pair)
     PTable<String, Pair<Pair<String, Long>, FlatVariantCall>> keyedRecords =
-        flatRecords.parallelDo(new ExtractPartitionKeyFn(segmentSize, sampleGroup),
+        flatRecords.parallelDo(
+            new ExtractSecondaryKeyFromFlatVariantCallFn(segmentSize, sampleGroup),
             tableOf(strings(), pairs(pairs(strings(), longs()), flatRecords.getPType())));
     // do the sort, and extract the partition key and full record
     PTable<String, FlatVariantCall> partitionedAndSortedRecords =
         SecondarySort.sortAndApply(keyedRecords, new ExtractEntityFn(),
             tableOf(strings(), Avros.specifics(FlatVariantCall.class)));
     return partitionedAndSortedRecords;
+  }
+
+  public static PTable<String, FlatVariantCall> partitionAndSortReduceSide(
+      PCollection<Variant> records, long segmentSize, String sampleGroup) {
+    return records
+        .by(new ExtractPartitionKeyFromVariantFn(segmentSize, sampleGroup), strings())
+        .groupByKey()
+        .parallelDo(new FlattenVariantsFn(),
+            tableOf(strings(), Avros.specifics(FlatVariantCall.class)));
+  }
+
+  public static String extractPartitionKey(Variant variant, long segmentSize,
+      String sampleGroup) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("chr=").append(variant.getReferenceName());
+    sb.append("/pos=").append(getRangeStart(segmentSize, variant.getStart()));
+    sb.append("/sample_group=").append(sampleGroup);
+    return sb.toString();
   }
 
   public static String extractPartitionKey(FlatVariantCall variant, long segmentSize,
@@ -69,25 +97,45 @@ public final class CrunchUtils {
    * Turns a variant call into a (partition key, (secondary key, variant call)) pair,
    * where the secondary key is a (sample ID, position) pair.
    */
-  private static final class ExtractPartitionKeyFn
-      extends DoFn<FlatVariantCall, Pair<String, Pair<Pair<String, Long>, FlatVariantCall>>> {
+  private static final class ExtractSecondaryKeyFromFlatVariantCallFn
+      extends MapFn<FlatVariantCall, Pair<String, Pair<Pair<String, Long>, FlatVariantCall>>> {
     private long segmentSize;
     private String sampleGroup;
 
-    private ExtractPartitionKeyFn(long segmentSize, String sampleGroup) {
+    private ExtractSecondaryKeyFromFlatVariantCallFn(long segmentSize, String sampleGroup) {
       this.segmentSize = segmentSize;
       this.sampleGroup = sampleGroup;
     }
 
     @Override
-    public void process(FlatVariantCall input,
-        Emitter<Pair<String, Pair<Pair<String, Long>, FlatVariantCall>>> emitter) {
+    public Pair<String, Pair<Pair<String, Long>, FlatVariantCall>> map(FlatVariantCall
+        input) {
       String partitionKey = extractPartitionKey(input, segmentSize, sampleGroup);
       Pair<String, Long> secondaryKey = Pair.of(input.getCallSetId().toString(), input
           .getStart());
-      emitter.emit(Pair.of(partitionKey, Pair.of(secondaryKey, input)));
+      return Pair.of(partitionKey, Pair.of(secondaryKey, input));
     }
   }
+
+  /*
+   * Turns a variant call into a (partition key, variant call) pair.
+   */
+  private static final class ExtractPartitionKeyFromVariantFn
+      extends MapFn<Variant, String> {
+    private long segmentSize;
+    private String sampleGroup;
+
+    private ExtractPartitionKeyFromVariantFn(long segmentSize, String sampleGroup) {
+      this.segmentSize = segmentSize;
+      this.sampleGroup = sampleGroup;
+    }
+
+    @Override
+    public String map(Variant input) {
+      return extractPartitionKey(input, segmentSize, sampleGroup);
+    }
+  }
+
   /*
    * Turns a (partition key, (secondary key, flat variant call)) pair into a
    * (partition key, flat variant call) pair.
@@ -106,23 +154,43 @@ public final class CrunchUtils {
       }
     }
   }
+
   /*
-   * Turns a (partition key, list[secondary key, variant call]) pair into a series of
+   * Turns a (partition key, list[variant call]) pair into a series of
    * (partition key, flat variant call) pairs, expanding the calls (samples) in the variant.
    */
-  private static final class ExtractFlatVariantsFn extends
-      DoFn<Pair<String, Iterable<Pair<Pair<String, Long>, Variant>>>,
+  private static final class FlattenVariantsFn extends
+      DoFn<Pair<String, Iterable<Variant>>,
           Pair<String, FlatVariantCall>> {
 
     @Override
-    public void process(Pair<String, Iterable<Pair<Pair<String, Long>, Variant>>> input,
+    public void process(Pair<String, Iterable<Variant>> input,
         Emitter<Pair<String, FlatVariantCall>> emitter) {
       String partitionKey = input.first();
-      for (Pair<Pair<String, Long>, Variant> pair : input.second()) {
-        Variant variant = pair.second();
+      // flatten
+      long count = 0;
+      List<FlatVariantCall> flatVariants = Lists.newArrayList();
+      for (Variant variant: input.second()) {
         for (Call call : variant.getCalls()) {
-          emitter.emit(Pair.of(partitionKey, flatten(variant, call)));
+          flatVariants.add(flatten(variant, call));
+          if ((++count % 1000000) == 0) {
+            LOG.info("Flattened {} variants", count);
+          }
         }
+      }
+      // sort by sample ID then position
+      Collections.sort(flatVariants, new Comparator<FlatVariantCall>() {
+        @Override
+        public int compare(FlatVariantCall c1, FlatVariantCall c2) {
+          int c = c1.getCallSetId().toString().compareTo(c2.getCallSetId().toString());
+          if (c != 0) {
+            return c;
+          }
+          return Long.compare(c1.getStart(), c2.getStart());
+        }
+      });
+      for (FlatVariantCall flat : flatVariants) {
+        emitter.emit(Pair.of(partitionKey, flat));
       }
     }
   }

--- a/src/main/java/com/cloudera/science/quince/LoadVariantsTool.java
+++ b/src/main/java/com/cloudera/science/quince/LoadVariantsTool.java
@@ -63,6 +63,11 @@ public class LoadVariantsTool extends Configured implements Tool {
       description="The number of base pairs in each segment partition.")
   private long segmentSize = 1000000;
 
+  @Parameter(names="--sort-reduce-side",
+      description="Sorting is done on the reduce side (takes more memory) rather than " +
+          "using the shuffle (slower).")
+  private boolean sortReduceSide = false;
+
   @Override
   public int run(String[] args) throws Exception {
     JCommander jc = new JCommander(this);
@@ -97,7 +102,9 @@ public class LoadVariantsTool extends Configured implements Tool {
     System.out.println("Num reducers: " + numReducers);
 
     PTable<String, FlatVariantCall> partitioned =
-        CrunchUtils.partitionAndSort(records, segmentSize, sampleGroup);
+        sortReduceSide ?
+        CrunchUtils.partitionAndSortReduceSide(records, segmentSize, sampleGroup) :
+        CrunchUtils.partitionAndSortUsingShuffle(records, segmentSize, sampleGroup);
 
     try {
       Path outputPath = new Path(outputPathString);


### PR DESCRIPTION
This changes the default to sort on the reduce side, but leaves an option to use the shuffle (which might be needed in the case of very large files e.g. when doing gVCF expansion).