### PR TITLE
Add a tool to print samples in VCF files, and add a new option

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,21 @@ impala-shell -q 'compute stats datasets.variants_flat_locuspart'
 impala-shell -q 'show partitions datasets.variants_flat_locuspart'
 ```
 
+### Loading only a subset of the samples in VCF files
+
+By default all the samples from the VCF files are loaded. If you want to only include 
+some of the samples, then use the `--samples` argument with a comma-separated list of 
+sample IDs. E.g. 
+
+```bash
+hadoop jar target/quince-0.0.1-SNAPSHOT-job.jar \
+  com.cloudera.science.quince.LoadVariantsTool \
+...
+--sample-group sample3
+--samples NA12878,NA12891,NA12892
+...
+```
+
 ## Deleting data
 
 You can remove all the data with the following commands. _Note that the data will be 

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,12 @@ License.
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <version>1.12.0</version>
+      <scope>test</scope>
+    </dependency>
 
     <!-- dependencies for loading from VCF -->
     <dependency>

--- a/src/main/java/com/cloudera/science/quince/FlattenVariantFn.java
+++ b/src/main/java/com/cloudera/science/quince/FlattenVariantFn.java
@@ -16,6 +16,7 @@
 package com.cloudera.science.quince;
 
 import java.util.List;
+import java.util.Set;
 import org.apache.crunch.DoFn;
 import org.apache.crunch.Emitter;
 import org.ga4gh.models.Call;
@@ -23,6 +24,12 @@ import org.ga4gh.models.FlatVariantCall;
 import org.ga4gh.models.Variant;
 
 class FlattenVariantFn extends DoFn<Variant, FlatVariantCall> {
+
+  private Set<String> samples;
+
+  public FlattenVariantFn(Set<String> samples) {
+    this.samples = samples;
+  }
 
   public static FlatVariantCall flatten(Variant variant, Call call) {
     FlatVariantCall flatVariantCall = new FlatVariantCall();
@@ -56,7 +63,9 @@ class FlattenVariantFn extends DoFn<Variant, FlatVariantCall> {
   @Override
   public void process(Variant variant, Emitter<FlatVariantCall> emitter) {
     for (Call call : variant.getCalls()) {
-      emitter.emit(flatten(variant, call));
+      if (samples == null || samples.contains(call.getCallSetId())) {
+        emitter.emit(flatten(variant, call));
+      }
     }
   }
   private static <T> T get(List<T> names, int index) {

--- a/src/main/java/com/cloudera/science/quince/PrintSamplesTool.java
+++ b/src/main/java/com/cloudera/science/quince/PrintSamplesTool.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2015, Cloudera, Inc. All Rights Reserved.
+ *
+ * Cloudera, Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"). You may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for
+ * the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package com.cloudera.science.quince;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
+import com.beust.jcommander.Parameters;
+import com.google.common.base.Joiner;
+import com.google.common.collect.Iterables;
+import java.util.List;
+import java.util.Set;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.conf.Configured;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.util.Tool;
+import org.apache.hadoop.util.ToolRunner;
+
+/**
+ * Prints the unique sample IDs stored in VCF files.
+ */
+@Parameters(commandDescription = "Print samples tool")
+public class PrintSamplesTool extends Configured implements Tool {
+
+  @Parameter(description="<input-path>")
+  private List<String> paths;
+
+  @Parameter(names="--samples-per-line")
+  private int samplesPerLine = 1;
+
+  @Override
+  public int run(String[] args) throws Exception {
+    JCommander jc = new JCommander(this);
+    try {
+      jc.parse(args);
+    } catch (ParameterException e) {
+      jc.usage();
+      return 1;
+    }
+
+    if (paths == null || paths.size() != 1) {
+      jc.usage();
+      return 1;
+    }
+
+    String inputPathString = paths.get(0);
+
+    Configuration conf = getConf();
+    Path inputPath = new Path(inputPathString);
+
+    Path[] vcfs = FileUtils.findVcfs(inputPath, conf);
+    Set<String> samples = SampleUtils.uniqueSamples(conf, vcfs);
+
+    if (samplesPerLine == 0) { // all on one line
+      System.out.println(Joiner.on(',').join(samples));
+    } else {
+      for (List<String> line : Iterables.partition(samples, samplesPerLine)) {
+        System.out.println(Joiner.on(',').join(line));
+      }
+    }
+
+    return 0;
+  }
+
+  public static void main(String[] args) throws Exception {
+    int exitCode = ToolRunner.run(new PrintSamplesTool(), args);
+    System.exit(exitCode);
+  }
+
+}

--- a/src/main/java/com/cloudera/science/quince/SampleUtils.java
+++ b/src/main/java/com/cloudera/science/quince/SampleUtils.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2015, Cloudera, Inc. All Rights Reserved.
+ *
+ * Cloudera, Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"). You may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for
+ * the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package com.cloudera.science.quince;
+
+import htsjdk.variant.vcf.VCFHeader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.opencb.hpg.bigdata.core.converters.FullVcfCodec;
+import org.opencb.hpg.bigdata.core.io.VcfBlockIterator;
+
+public final class SampleUtils {
+
+  private SampleUtils() {
+  }
+
+  public static Set<String> uniqueSamples(Configuration conf, Path[] vcfs)
+      throws IOException {
+    Set<String> samples = new LinkedHashSet<>();
+    for (Path vcf : vcfs) {
+      InputStream inputStream = vcf.getFileSystem(conf).open(vcf);
+      VcfBlockIterator iterator = new VcfBlockIterator(inputStream, new FullVcfCodec());
+      VCFHeader header = iterator.getHeader();
+      samples.addAll(header.getGenotypeSamples());
+    }
+    return samples;
+  }
+}

--- a/src/test/java/com/cloudera/science/quince/FlattenVariantsTest.java
+++ b/src/test/java/com/cloudera/science/quince/FlattenVariantsTest.java
@@ -62,7 +62,7 @@ public class FlattenVariantsTest {
       public void flush() { }
     }
 
-    FlattenVariantFn fn = new FlattenVariantFn();
+    FlattenVariantFn fn = new FlattenVariantFn(null);
     CapturingEmitter emitter = new CapturingEmitter();
     fn.process(v, emitter);
 

--- a/src/test/java/com/cloudera/science/quince/PrintSamplesToolIT.java
+++ b/src/test/java/com/cloudera/science/quince/PrintSamplesToolIT.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2015, Cloudera, Inc. All Rights Reserved.
+ *
+ * Cloudera, Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"). You may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This software is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for
+ * the specific language governing permissions and limitations under the
+ * License.
+ */
+
+package com.cloudera.science.quince;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.SystemOutRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class PrintSamplesToolIT {
+
+  private PrintSamplesTool tool;
+
+  @Rule
+  public final SystemOutRule systemOutRule = new SystemOutRule().enableLog();
+
+  @Before
+  public void setUp() {
+    tool = new PrintSamplesTool();
+    Configuration conf = new Configuration();
+    tool.setConf(conf);
+  }
+
+  @Test
+  public void testOneSamplePerLine() throws Exception {
+    int exitCode = tool.run(new String[]{"datasets/variants_vcf"});
+    assertEquals(0, exitCode);
+    assertTrue(systemOutRule.getLog().contains("NA12878\nNA12891\nNA12892\n"));
+  }
+
+  @Test
+  public void testTwoPerLine() throws Exception {
+    int exitCode = tool.run(new String[]{"datasets/variants_vcf", "--samples-per-line", "2"});
+    assertEquals(0, exitCode);
+    assertTrue(systemOutRule.getLog().contains("NA12878,NA12891\nNA12892\n"));
+  }
+
+  @Test
+  public void testAllOnOneLine() throws Exception {
+    int exitCode = tool.run(new String[]{"datasets/variants_vcf", "--samples-per-line", "0"});
+    assertEquals(0, exitCode);
+    assertTrue(systemOutRule.getLog().contains("NA12878,NA12891,NA12892\n"));
+  }
+
+}


### PR DESCRIPTION
--samples to LoadVariantsTool to restrict the samples loaded from
VCF files.

This makes it possible to control the number of samples in a sample group. For example, we can load the 1000 genomes dataset in smaller batches, which is useful for simulating how sample data may arrive.